### PR TITLE
Fixing that sometimes email adresses are lost

### DIFF
--- a/calcFieldsUpdater.php
+++ b/calcFieldsUpdater.php
@@ -66,6 +66,7 @@ for ($offset = 0; true; $offset += $page_length) {
 		$b->update_date_modified = false;
 		$b->update_modified_by = false;
 		$b->tracker_visibility = false;
+		$b->fill_in_relationship_fields();
 		$b->save();
 	}
 };


### PR DESCRIPTION
During runs on beans which extends from Person some email adresses
are lost. The problem only exists for newer beans because on an old
database content no emails are deleted. On a live database nearly
every one is marked as deleted.

The problem is AFAIK that the list fetching doesn't do all the magic bean processing that is necessary for our updating task.
